### PR TITLE
Changed the SDK-style projects to ref the same Newtonsoft version as …

### DIFF
--- a/SonarQube.Client.Tests/SonarQube.Client.Tests.csproj
+++ b/SonarQube.Client.Tests/SonarQube.Client.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />

--- a/SonarQube.Client/SonarQube.Client.csproj
+++ b/SonarQube.Client/SonarQube.Client.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <!-- When changing this reference update ProtocCompiler property too! -->
     <PackageReference Include="Grpc.Tools" Version="1.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
…the old-style projects

SLVS is currently the only consumer of this module, and we need NewtonSoft v6 so we can target VS2015 (unless we start shipping the  NewtonSoft dll in the VSIX).