### PR TITLE
Dropped netstandard2.0 as a target - not currently used

### DIFF
--- a/SonarQube.Client/SonarQube.Client.csproj
+++ b/SonarQube.Client/SonarQube.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46</TargetFrameworks>
     <AssemblyName>SonarQube.Client</AssemblyName>
     <LangVersion>6</LangVersion>
     <RootNamespace>SonarQube.Client</RootNamespace>


### PR DESCRIPTION
Causes problems when trying to restore NuGet packages since NewtonSoft v6.0.8 isn't compatible with netstandard2