### PR TITLE
Remove LangVersion settings from the projects

### DIFF
--- a/SonarQube.Client.Tests/SonarQube.Client.Tests.csproj
+++ b/SonarQube.Client.Tests/SonarQube.Client.Tests.csproj
@@ -7,7 +7,6 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>SonarQube.Client.Tests</RootNamespace>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SonarQube.Client/SonarQube.Client.csproj
+++ b/SonarQube.Client/SonarQube.Client.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
     <AssemblyName>SonarQube.Client</AssemblyName>
-    <LangVersion>6</LangVersion>
     <RootNamespace>SonarQube.Client</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RequiresSigning>true</RequiresSigning>


### PR DESCRIPTION
We'll rely on the default setting i.e. the compiler will warn us if we use a feature that is not supported
by the target framework.

For some reason the language level was set to a lower level than the one supported by the target framework.