### PR TITLE
Added FilePath property to IssueLocation

### DIFF
--- a/SonarQube.Client.Tests/Models/IssueFlowTests.cs
+++ b/SonarQube.Client.Tests/Models/IssueFlowTests.cs
@@ -41,8 +41,8 @@ namespace SonarQube.Client.Tests.Models
         {
             var locations = new List<IssueLocation>
             {
-                new IssueLocation("component1", null, "message1"),
-                new IssueLocation("component2", null, "message2")
+                new IssueLocation("file1", "component1", null, "message1"),
+                new IssueLocation("file2", "component2", null, "message2")
             };
 
             var testSubject = new IssueFlow(locations);

--- a/SonarQube.Client.Tests/Requests/Api/V7_20/GetIssuesRequestTests.cs
+++ b/SonarQube.Client.Tests/Requests/Api/V7_20/GetIssuesRequestTests.cs
@@ -207,7 +207,8 @@ namespace SonarQube.Client.Tests.Requests.Api.V7_20
             result.Flows[1].Locations.Count().Should().Be(2);
 
             var firstFlowFirstLocation = results[0].Flows[0].Locations[0];
-            firstFlowFirstLocation.Component.Should().Be("myprojectkey:projectroot/Controllers/WeatherForecastController.cs");
+            firstFlowFirstLocation.ModuleKey.Should().Be("myprojectkey:projectroot/Controllers/WeatherForecastController.cs");
+            firstFlowFirstLocation.FilePath.Should().Be("projectroot/Controllers/WeatherForecastController.cs");
             firstFlowFirstLocation.Message.Should().Be("sink: tainted value is used to perform a security-sensitive operation");
             firstFlowFirstLocation.TextRange.StartLine.Should().Be(43);
             firstFlowFirstLocation.TextRange.EndLine.Should().Be(43);
@@ -215,7 +216,8 @@ namespace SonarQube.Client.Tests.Requests.Api.V7_20
             firstFlowFirstLocation.TextRange.EndOffset.Should().Be(43);
 
             var seconFlowSecondLocation = results[0].Flows[1].Locations[1];
-            seconFlowSecondLocation.Component.Should().Be("myprojectkey:projectroot/Controllers/Helper.cs");
+            seconFlowSecondLocation.ModuleKey.Should().Be("myprojectkey:projectroot/Controllers/Helper.cs");
+            seconFlowSecondLocation.FilePath.Should().Be("projectroot/Controllers/Helper.cs");
             seconFlowSecondLocation.Message.Should().Be("tainted value is propagated");
             seconFlowSecondLocation.TextRange.StartLine.Should().Be(5);
             seconFlowSecondLocation.TextRange.EndLine.Should().Be(5);

--- a/SonarQube.Client/Api/V7_20/GetIssuesRequest.cs
+++ b/SonarQube.Client/Api/V7_20/GetIssuesRequest.cs
@@ -47,11 +47,14 @@ namespace SonarQube.Client.Api.V7_20
         {
             var root = JObject.Parse(response);
 
+            // This is a paged request so ParseResponse will be called once for each "page"
+            // of the response. However, we expect each page to be self-contained, so we want
+            // to rebuild the lookup each time.
             componentKeyPathLookup = GetComponentKeyPathLookup(root);
 
             return root["issues"]
                 .ToObject<ServerIssue[]>()
-                .Select(issue => ToSonarQubeIssue(issue))
+                .Select(ToSonarQubeIssue)
                 .ToArray();
         }
 
@@ -62,8 +65,6 @@ namespace SonarQube.Client.Api.V7_20
         /// issues and components, where each issue's "component" property points to a component with
         /// the same "key". We obtain the FilePath of each issue from its corresponding component.
         /// </summary>
-        /// <remarks>A new instance of this class is created for each request so it is safe to store the
-        /// lookup in an instance variable so we don't have to pass it around.</remarks>
         private ILookup<string, string> componentKeyPathLookup;
 
         private static ILookup<string, string> GetComponentKeyPathLookup(JObject root)

--- a/SonarQube.Client/Models/SonarQubeIssue.cs
+++ b/SonarQube.Client/Models/SonarQubeIssue.cs
@@ -62,14 +62,16 @@ namespace SonarQube.Client.Models
 
     public class IssueLocation
     {
-        public IssueLocation(string component, IssueTextRange textRange, string message)
+        public IssueLocation(string filePath, string moduleKey, IssueTextRange textRange, string message)
         {
-            Component = component;
+            FilePath = filePath;
+            ModuleKey = moduleKey;
             TextRange = textRange;
             Message = message;
         }
 
-        public string Component { get; }
+        public string FilePath { get; }
+        public string ModuleKey { get; }
         public IssueTextRange TextRange { get; }
         public string Message { get; }
     }


### PR DESCRIPTION
Add FilePath to `IssueLocation` data class.

`IssueLocation` now has the same `FilePath` and `ModuleKey` properties as `SonarQubeIssue`, calculated in the same way.