### PR TITLE
Dp/line hash

### DIFF
--- a/SonarQube.Client.Tests/Requests/DefaultConfiguration_Configure.cs
+++ b/SonarQube.Client.Tests/Requests/DefaultConfiguration_Configure.cs
@@ -60,7 +60,7 @@ namespace SonarQube.Client.Tests.Requests
                     "Registered SonarQube.Client.Api.V6_60.GetRoslynExportProfileRequest for 6.6",
                     "Registered SonarQube.Client.Api.V7_00.GetOrganizationsRequest for 7.0",
                     "Registered SonarQube.Client.Api.V7_20.GetIssuesRequestWrapper for 7.2",
-                    "Registered SonarQube.Client.Api.V8_1.GetHotspotRequest for 8.1"
+                    "Registered SonarQube.Client.Api.V8_6.GetHotspotRequest for 8.6"
                 };
 
             DefaultConfiguration.Configure(new RequestFactory(logger));

--- a/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
+++ b/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
@@ -35,7 +35,7 @@ namespace SonarQube.Client.Tests
         public async Task GetHotspot_Response_From_SonarQube()
         {
             const string hotspotKey = "AW9mgJw6eFC3pGl94Wrf";
-            await ConnectToSonarQube("8.1.0.0");
+            await ConnectToSonarQube("8.6.0.0");
 
             SetupRequest($"api/hotspots/show?hotspot={hotspotKey}", @"{
   ""key"": ""AW9mgJw6eFC3pGl94Wrf"",

--- a/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
+++ b/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
@@ -70,7 +70,6 @@ namespace SonarQube.Client.Tests
     ""endOffset"": 41
   },
   ""status"": ""TO_REVIEW"",
-  ""line"": 32,
   ""hash"": ""106b6a42b6099a78bbb233937f36c4bc"",
   ""message"": ""message"",
   ""assignee"": ""joe"",

--- a/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
+++ b/SonarQube.Client.Tests/SonarQubeService_GetHotspotAsync.cs
@@ -58,7 +58,10 @@ namespace SonarQube.Client.Tests
     ""key"": ""java:S4787"",
     ""name"": ""rule-name"",
     ""securityCategory"": ""others"",
-    ""vulnerabilityProbability"": ""LOW""
+    ""vulnerabilityProbability"": ""LOW"",
+    ""riskDescription"": ""risk desc"",
+    ""vulnerabilityDescription"": ""vuln desc"",
+    ""fixRecommendations"": ""fix rec""
   },
   ""textRange"": {
     ""startLine"": 5,
@@ -67,6 +70,8 @@ namespace SonarQube.Client.Tests
     ""endOffset"": 41
   },
   ""status"": ""TO_REVIEW"",
+  ""line"": 32,
+  ""hash"": ""106b6a42b6099a78bbb233937f36c4bc"",
   ""message"": ""message"",
   ""assignee"": ""joe"",
   ""author"": ""joe"",
@@ -155,6 +160,7 @@ namespace SonarQube.Client.Tests
 
             result.HotspotKey.Should().Be(hotspotKey);
             result.Message.Should().Be("message");
+            result.LineHash.Should().Be("106b6a42b6099a78bbb233937f36c4bc");
             result.Assignee.Should().Be("joe");
             result.Status.Should().Be("TO_REVIEW");
 
@@ -165,10 +171,13 @@ namespace SonarQube.Client.Tests
             result.ComponentKey.Should().Be("com.sonarsource:test-project:src/main/java/com/sonarsource/FourthClass.java");
             result.FilePath.Should().Be("src\\main\\java\\com\\sonarsource\\FourthClass.java");
 
-            result.RuleKey.Should().Be("java:S4787");
-            result.RuleName.Should().Be("rule-name");
-            result.SecurityCategory.Should().Be("others");
-            result.VulnerabilityProbability.Should().Be("LOW");
+            result.Rule.RuleKey.Should().Be("java:S4787");
+            result.Rule.RuleName.Should().Be("rule-name");
+            result.Rule.SecurityCategory.Should().Be("others");
+            result.Rule.VulnerabilityProbability.Should().Be("LOW");
+            result.Rule.RiskDescription.Should().Be("risk desc");
+            result.Rule.VulnerabilityDescription.Should().Be("vuln desc");
+            result.Rule.FixRecommendations.Should().Be("fix rec");
 
             result.TextRange.Should().NotBeNull();
             result.TextRange.StartLine.Should().Be(5);

--- a/SonarQube.Client/Api/DefaultConfiguration.cs
+++ b/SonarQube.Client/Api/DefaultConfiguration.cs
@@ -50,7 +50,7 @@ namespace SonarQube.Client.Api
                 .RegisterRequest<IGetRoslynExportProfileRequest, V6_60.GetRoslynExportProfileRequest>("6.6")
                 .RegisterRequest<IGetOrganizationsRequest, V7_00.GetOrganizationsRequest>("7.0")
                 .RegisterRequest<IGetIssuesRequest, V7_20.GetIssuesRequestWrapper>("7.2")
-                .RegisterRequest<IGetHotspotRequest, V8_1.GetHotspotRequest>("8.1");
+                .RegisterRequest<IGetHotspotRequest, V8_6.GetHotspotRequest>("8.6");
             return requestFactory;
         }
     }

--- a/SonarQube.Client/Api/V8_1/GetHotspotRequest.cs
+++ b/SonarQube.Client/Api/V8_1/GetHotspotRequest.cs
@@ -28,8 +28,6 @@ namespace SonarQube.Client.Api.V8_1
 {
     public class GetHotspotRequest : RequestBase<SonarQubeHotspot>, IGetHotspotRequest
     {
-        //TODO - this is an internal API - change to use a public API when available
-
         protected override string Path => "api/hotspots/show";
 
         [JsonProperty("hotspot")]
@@ -38,9 +36,21 @@ namespace SonarQube.Client.Api.V8_1
         protected override SonarQubeHotspot ParseResponse(string response)
         {
             var serverResponse = JObject.Parse(response).ToObject<GetHotspotResponse>();
+
+            var rule = new SonarQubeHotspotRule(
+                serverResponse.Rule.Key,
+                serverResponse.Rule.Name,
+                serverResponse.Rule.SecurityCategory,
+                serverResponse.Rule.VulnerabilityProbability,
+                serverResponse.Rule.RiskDescription,
+                serverResponse.Rule.VulnerabilityDescription,
+                serverResponse.Rule.FixRecommendations
+            );
+
             var hotspot = new SonarQubeHotspot(
                 serverResponse.Key,
                 serverResponse.Message,
+                serverResponse.Hash,
                 serverResponse.Assignee,
                 serverResponse.Status,
                 serverResponse.Project.Organization,
@@ -48,10 +58,7 @@ namespace SonarQube.Client.Api.V8_1
                 serverResponse.Project.Name,
                 serverResponse.Component.Key,
                 FilePathNormalizer.NormalizeSonarQubePath(serverResponse.Component.Path),
-                serverResponse.Rule.Key,
-                serverResponse.Rule.Name,
-                serverResponse.Rule.SecurityCategory,
-                serverResponse.Rule.VulnerabilityProbability,
+                rule,
                 ToIssueTextRange(serverResponse.TextRange)
             );
 
@@ -71,6 +78,9 @@ namespace SonarQube.Client.Api.V8_1
 
             [JsonProperty("line")]
             public int Line { get; set; }
+
+            [JsonProperty("hash")]
+            public string Hash { get; set; }
 
             [JsonProperty("message")]
             public string Message { get; set; }
@@ -125,6 +135,15 @@ namespace SonarQube.Client.Api.V8_1
 
             [JsonProperty("vulnerabilityProbability")]
             public string VulnerabilityProbability { get; set; }
+
+            [JsonProperty("riskDescription")]
+            public string RiskDescription { get; set; }
+
+            [JsonProperty("vulnerabilityDescription")]
+            public string VulnerabilityDescription { get; set; }
+
+            [JsonProperty("fixRecommendations")]
+            public string FixRecommendations { get; set; }
         }
 
         private class ServerTextRange

--- a/SonarQube.Client/Api/V8_6/GetHotspotRequest.cs
+++ b/SonarQube.Client/Api/V8_6/GetHotspotRequest.cs
@@ -24,7 +24,7 @@ using SonarQube.Client.Helpers;
 using SonarQube.Client.Models;
 using SonarQube.Client.Requests;
 
-namespace SonarQube.Client.Api.V8_1
+namespace SonarQube.Client.Api.V8_6
 {
     public class GetHotspotRequest : RequestBase<SonarQubeHotspot>, IGetHotspotRequest
     {

--- a/SonarQube.Client/Api/V8_6/GetHotspotRequest.cs
+++ b/SonarQube.Client/Api/V8_6/GetHotspotRequest.cs
@@ -76,9 +76,6 @@ namespace SonarQube.Client.Api.V8_6
             [JsonProperty("status")]
             public string Status { get; set; }
 
-            [JsonProperty("line")]
-            public int Line { get; set; }
-
             [JsonProperty("hash")]
             public string Hash { get; set; }
 

--- a/SonarQube.Client/Models/SonarQubeHotspot.cs
+++ b/SonarQube.Client/Models/SonarQubeHotspot.cs
@@ -23,14 +23,15 @@ namespace SonarQube.Client.Models
     public class SonarQubeHotspot
     {
         public SonarQubeHotspot(
-            string hotspotKey, string message, string assignee, string status,
+            string hotspotKey, string message, string lineHash, string assignee, string status,
             string organization, string projectKey, string projectName,
             string componentKey, string filePath,
-            string ruleKey, string ruleName, string securityCategory, 
-            string vulnerabilityProbability, IssueTextRange textRange)
+            SonarQubeHotspotRule rule,
+            IssueTextRange textRange)
         {
             HotspotKey = hotspotKey;
             Message = message;
+            LineHash = lineHash;
             Assignee = assignee;
             Status = status;
 
@@ -41,15 +42,13 @@ namespace SonarQube.Client.Models
             ComponentKey = componentKey;
             FilePath = filePath;
 
-            RuleKey = ruleKey;
-            RuleName = ruleName;
-            SecurityCategory = securityCategory;
-            VulnerabilityProbability = vulnerabilityProbability;
+            Rule = rule;
             TextRange = textRange;
         }
 
         public string HotspotKey { get; }
         public string Message { get; }
+        public string LineHash { get; }
         public string Assignee { get; }
         public string Status { get; }
         public IssueTextRange TextRange { get; }
@@ -64,10 +63,7 @@ namespace SonarQube.Client.Models
         /// The path is in Windows format i.e. the directory separators are backslashes
         /// </remarks>
         public string FilePath { get; }
-        public string RuleKey { get; }
-        public string RuleName { get; }
-        public string SecurityCategory { get; }
-        public string VulnerabilityProbability { get; }
+        public SonarQubeHotspotRule Rule { get; }
         public string ProjectKey { get; }
         public string ProjectName { get; }
     }

--- a/SonarQube.Client/Models/SonarQubeHotspotRule.cs
+++ b/SonarQube.Client/Models/SonarQubeHotspotRule.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarQube Client
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarQube.Client.Models
+{
+    public class SonarQubeHotspotRule
+    {
+        public SonarQubeHotspotRule(string ruleKey, string ruleName,
+            string securityCategory, string vulnProbability,
+            string riskDescription, string vulnDescription, string fixRecommendations)
+        {
+            RuleKey = ruleKey;
+            RuleName = ruleName;
+            SecurityCategory = securityCategory;
+            VulnerabilityProbability = vulnProbability;
+            RiskDescription = riskDescription;
+            VulnerabilityDescription = vulnDescription;
+            FixRecommendations = fixRecommendations;
+        }
+
+        public string RuleKey { get; }
+        public string RuleName { get; }
+        public string SecurityCategory { get; }
+        public string VulnerabilityProbability { get; }
+        public string RiskDescription { get; }
+        public string VulnerabilityDescription { get; }
+        public string FixRecommendations { get; }
+    }
+}


### PR DESCRIPTION
Update GetHotspot request to use public API:
* updated minimum SQ version to v8.6
* added extra data fields - line hash and rule description fields.

Relates to [SLVS #1905](https://github.com/SonarSource/sonarlint-visualstudio/issues/1905)