### PR TITLE
Added abstractions to support handling SonarCloud requests separately

### DIFF
--- a/SonarQube.Client.Tests/Requests/RequestFactoryTests.cs
+++ b/SonarQube.Client.Tests/Requests/RequestFactoryTests.cs
@@ -42,7 +42,7 @@ namespace SonarQube.Client.Tests.Requests
         public void Create_Throws_When_Not_Registered()
         {
             var factory = new RequestFactory(logger);
-            Action action = () => factory.Create<ITestRequest>(new Version(1, 0, 0));
+            Action action = () => factory.Create<ITestRequest>(CreateServerInfo("1.0.0"));
             action.Should().ThrowExactly<InvalidOperationException>()
                 .WithMessage("Could not find factory for 'ITestRequest'.");
 
@@ -55,7 +55,7 @@ namespace SonarQube.Client.Tests.Requests
             var factory = new RequestFactory(logger);
             factory.RegisterRequest<ITestRequest, TestRequest1>("2.0.0");
 
-            Action action = () => factory.Create<ITestRequest>(new Version(1, 0, 0));
+            Action action = () => factory.Create<ITestRequest>(CreateServerInfo("1.0.0"));
             action.Should().ThrowExactly<InvalidOperationException>()
                 .WithMessage("Could not find compatible implementation of 'ITestRequest' for SonarQube 1.0.0.");
 
@@ -68,7 +68,7 @@ namespace SonarQube.Client.Tests.Requests
             var factory = new RequestFactory(logger);
             factory.RegisterRequest<ITestRequest, TestRequest1>("1.1.0");
 
-            factory.Create<ITestRequest>(new Version(1, 2, 3)).Should().BeOfType<TestRequest1>();
+            factory.Create<ITestRequest>(CreateServerInfo("1.2.3")).Should().BeOfType<TestRequest1>();
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace SonarQube.Client.Tests.Requests
                     "Registered SonarQube.Client.Tests.Requests.RequestFactoryTests+TestRequest1 for 1.0.0",
                 });
 
-            factory.Create<ITestRequest>(new Version(1, 0, 0)).Should().BeOfType<TestRequest1>();
+            factory.Create<ITestRequest>(CreateServerInfo("1.0.0")).Should().BeOfType<TestRequest1>();
             logger.DebugMessages.Should().ContainInOrder(
                 new[]
                 {
@@ -98,8 +98,8 @@ namespace SonarQube.Client.Tests.Requests
             factory.RegisterRequest<ITestRequest, TestRequest1>("1.0.0");
             factory.RegisterRequest<IAnotherRequest, AnotherRequest1>("1.0.0");
 
-            factory.Create<IAnotherRequest>(new Version(1, 0, 0)).Should().BeOfType<AnotherRequest1>();
-            factory.Create<ITestRequest>(new Version(1, 0, 0)).Should().BeOfType<TestRequest1>();
+            factory.Create<IAnotherRequest>(CreateServerInfo("1.0.0")).Should().BeOfType<AnotherRequest1>();
+            factory.Create<ITestRequest>(CreateServerInfo("1.0.0")).Should().BeOfType<TestRequest1>();
         }
 
         [TestMethod]
@@ -140,6 +140,9 @@ namespace SonarQube.Client.Tests.Requests
             action.Should().ThrowExactly<ArgumentException>().And
                 .ParamName.Should().Be("version");
         }
+
+        private static ServerInfo CreateServerInfo(string version) =>
+            new ServerInfo(new Version(version), ServerType.SonarQube);
 
         public interface ITestRequest : IRequest
         {

--- a/SonarQube.Client.Tests/SonarQubeService_Lifecycle.cs
+++ b/SonarQube.Client.Tests/SonarQubeService_Lifecycle.cs
@@ -40,14 +40,14 @@ namespace SonarQube.Client.Tests
             SetupRequest("api/authentication/validate", "{ \"valid\": true }");
 
             service.IsConnected.Should().BeFalse();
-            service.SonarQubeVersion.Should().BeNull();
+            service.ServerInfo.Should().BeNull();
 
             await service.ConnectAsync(
                 new ConnectionInformation(new Uri("http://localhost"), "user", "pass".ToSecureString()),
                 CancellationToken.None);
 
             service.IsConnected.Should().BeTrue();
-            service.SonarQubeVersion.Should().Be(new Version("3.3.0.0"));
+            service.ServerInfo.Version.Should().Be(new Version("3.3.0.0"));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace SonarQube.Client.Tests
                 new ConnectionInformation(new Uri(inputUrl), "user", "pass".ToSecureString()),
                 CancellationToken.None);
 
-            service.IsSonarCloud.Should().BeFalse();
+            service.ServerInfo.ServerType.Should().Be(ServerType.SonarQube);
         }
 
         [TestMethod]
@@ -86,7 +86,7 @@ namespace SonarQube.Client.Tests
                 new ConnectionInformation(new Uri(inputUrl), "user", "pass".ToSecureString()),
                 CancellationToken.None);
 
-            service.IsSonarCloud.Should().BeTrue();
+            service.ServerInfo.ServerType.Should().Be(ServerType.SonarCloud);
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace SonarQube.Client.Tests
 
             // Assert
             service.IsConnected.Should().BeFalse();
-            service.SonarQubeVersion.Should().BeNull();
+            service.ServerInfo.Should().BeNull();
             disposed.Should().BeFalse();
         }
 
@@ -123,7 +123,7 @@ namespace SonarQube.Client.Tests
 
             // Assert
             service.IsConnected.Should().BeFalse();
-            service.SonarQubeVersion.Should().BeNull();
+            service.ServerInfo.Should().BeNull();
             disposed.Should().BeTrue();
         }
     }

--- a/SonarQube.Client.Tests/SonarQubeService_TestBase.cs
+++ b/SonarQube.Client.Tests/SonarQubeService_TestBase.cs
@@ -91,12 +91,14 @@ namespace SonarQube.Client.Tests
             // Sanity checks
             service.IsConnected.Should().BeTrue();
 
-            service.SonarQubeVersion.Should().Be(new Version(version));
+            service.ServerInfo.Version.Should().Be(new Version(version));
             logger.InfoMessages.Should().Contain(
                 x => x.StartsWith($"Connecting to '{serverUrl}", StringComparison.OrdinalIgnoreCase));
 
+            var serverTypeText = service.ServerInfo.ServerType == ServerType.SonarCloud ? "SonarCloud" : "SonarQube";
+
             logger.InfoMessages.Should().Contain(
-                x => x.StartsWith($"Connected to SonarQube '{version}'."));
+                x => x.StartsWith($"Connected to {serverTypeText} '{version}'."));
         }
 
         protected void ResetService()

--- a/SonarQube.Client/Api/DefaultConfiguration.cs
+++ b/SonarQube.Client/Api/DefaultConfiguration.cs
@@ -22,7 +22,7 @@ using SonarQube.Client.Requests;
 
 namespace SonarQube.Client.Api
 {
-    public static class DefaultConfiguration
+    internal static class DefaultConfiguration
     {
         public static RequestFactory Configure(RequestFactory requestFactory)
         {

--- a/SonarQube.Client/ISonarQubeService.cs
+++ b/SonarQube.Client/ISonarQubeService.cs
@@ -30,9 +30,7 @@ namespace SonarQube.Client
 {
     public interface ISonarQubeService
     {
-        Version SonarQubeVersion { get; }
-
-        bool IsSonarCloud { get; }
+        ServerInfo ServerInfo { get; }
 
         /// <summary>
         /// Returns whether organizations are available and being used

--- a/SonarQube.Client/Requests/IRequestFactory.cs
+++ b/SonarQube.Client/Requests/IRequestFactory.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarQube Client
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarQube.Client.Requests
+{
+    /// <summary>
+    /// Factory that creates request instance appropriate to the supplied server type/version
+    /// </summary>
+    internal interface IRequestFactory
+    {
+        TRequest Create<TRequest>(ServerInfo serverInfo) where TRequest : IRequest;
+    }
+}

--- a/SonarQube.Client/Requests/RequestFactory.cs
+++ b/SonarQube.Client/Requests/RequestFactory.cs
@@ -25,7 +25,12 @@ using SonarQube.Client.Logging;
 
 namespace SonarQube.Client.Requests
 {
-    public class RequestFactory
+    internal interface IRequestFactory
+    {
+        TRequest Create<TRequest>(Version version) where TRequest : IRequest;
+    }
+
+    internal class RequestFactory : IRequestFactory
     {
         /// <summary>
         /// Map between request type and a list with versioned request implementation factories.

--- a/SonarQube.Client/Requests/RequestFactory.cs
+++ b/SonarQube.Client/Requests/RequestFactory.cs
@@ -25,11 +25,6 @@ using SonarQube.Client.Logging;
 
 namespace SonarQube.Client.Requests
 {
-    internal interface IRequestFactory
-    {
-        TRequest Create<TRequest>(Version version) where TRequest : IRequest;
-    }
-
     internal class RequestFactory : IRequestFactory
     {
         /// <summary>
@@ -99,17 +94,18 @@ namespace SonarQube.Client.Requests
         /// Creates a new TRequest implementation for the specified SonarQube version.
         /// </summary>
         /// <typeparam name="TRequest">The type of the request implementation to create.</typeparam>
-        /// <param name="version">
+        /// <param name="serverInfo">
         /// SonarQube version to return a request implementation for. When the provided value is null
         /// returns the registered implementation with the highest version number.
         /// </param>
         /// <returns>New the newest TRequest implementation for the specified SonarQube version.</returns>
-        public TRequest Create<TRequest>(Version version)
+        public TRequest Create<TRequest>(ServerInfo serverInfo)
             where TRequest : IRequest
         {
             SortedList<Version, Func<IRequest>> map;
             if (registrations.TryGetValue(typeof(TRequest), out map))
             {
+                var version = serverInfo?.Version;
                 logger.Debug($"Looking up implementation of '{typeof(TRequest).Name}' for version '{version}' on thread '{System.Threading.Thread.CurrentThread.ManagedThreadId}'");
 
                 var factory = map

--- a/SonarQube.Client/ServerInfo.cs
+++ b/SonarQube.Client/ServerInfo.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * SonarQube Client
+ * Copyright (C) 2016-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarQube.Client
+{
+    /// <summary>
+    /// Describes the currently connected server
+    /// </summary>
+    public class ServerInfo
+    {
+        public ServerInfo(Version version, ServerType serverType)
+        {
+            Version = version;
+            ServerType = serverType;
+        }
+
+        public Version Version { get; }
+
+        public ServerType ServerType { get; }
+    }
+
+    public enum ServerType
+    {
+        SonarQube, SonarCloud
+    }
+}

--- a/SonarQube.Client/SonarQubeService.cs
+++ b/SonarQube.Client/SonarQubeService.cs
@@ -43,8 +43,6 @@ namespace SonarQube.Client
 
         private HttpClient httpClient;
 
-        public Version SonarQubeVersion { get; private set; }
-
         public async Task<bool> HasOrganizations(CancellationToken token)
         {
             EnsureIsConnected();
@@ -56,7 +54,7 @@ namespace SonarQube.Client
 
         public bool IsConnected { get; private set; }
 
-        public bool IsSonarCloud { get; private set; }
+        public ServerInfo ServerInfo { get; private set; }
 
         public SonarQubeService(HttpMessageHandler messageHandler, string userAgent, ILogger logger)
             : this(messageHandler, DefaultConfiguration.Configure(new RequestFactory(logger)), userAgent, logger)
@@ -110,7 +108,7 @@ namespace SonarQube.Client
         {
             EnsureIsConnected();
 
-            var request = requestFactory.Create<TRequest>(SonarQubeVersion);
+            var request = requestFactory.Create<TRequest>(ServerInfo);
             configure(request);
 
             var result = await request.InvokeAsync(httpClient, token);
@@ -136,14 +134,15 @@ namespace SonarQube.Client
             httpClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
 
             IsConnected = true;
-            IsSonarCloud = connection.IsSonarCloud;
+            var serverTypeDescription = connection.IsSonarCloud ? "SonarCloud" : "SonarQube";
 
-            logger.Debug($"Getting the version of SonarQube...");
+            logger.Debug($"Getting the version of {serverTypeDescription}...");
 
             var versionResponse = await InvokeRequestAsync<IGetVersionRequest, string>(token);
-            SonarQubeVersion = Version.Parse(versionResponse);
+            ServerInfo = new ServerInfo(Version.Parse(versionResponse),
+                connection.IsSonarCloud ? ServerType.SonarCloud : ServerType.SonarQube);
 
-            logger.Info($"Connected to SonarQube '{SonarQubeVersion}'.");
+            logger.Info($"Connected to {serverTypeDescription} '{ServerInfo.Version}'.");
 
             logger.Debug($"Validating the credentials...");
 
@@ -151,7 +150,7 @@ namespace SonarQube.Client
             if (!credentialResponse)
             {
                 IsConnected = false;
-                SonarQubeVersion = null;
+                ServerInfo = null;
                 throw new InvalidOperationException("Invalid credentials");
             }
 
@@ -166,7 +165,7 @@ namespace SonarQube.Client
             // Don't dispose the HttpClient when disconnecting. We'll need it if
             // the caller connects to another server.
             IsConnected = false;
-            SonarQubeVersion = null;
+            ServerInfo = null;
         }
 
         private void EnsureIsConnected()
@@ -355,7 +354,7 @@ namespace SonarQube.Client
             const string SonarQube_ViewHotspotRelativeUrl = "security_hotspots?id={0}&hotspots={1}";
             const string SonarCloud_ViewHotspotRelativeUrl = "project/security_hotspots?id={0}&hotspots={1}";
 
-            var urlFormat = IsSonarCloud ? SonarCloud_ViewHotspotRelativeUrl : SonarQube_ViewHotspotRelativeUrl;
+            var urlFormat = ServerInfo.ServerType == ServerType.SonarCloud ? SonarCloud_ViewHotspotRelativeUrl : SonarQube_ViewHotspotRelativeUrl;
 
             return new Uri(httpClient.BaseAddress, string.Format(urlFormat, projectKey, hotspotKey));
         }
@@ -372,7 +371,7 @@ namespace SonarQube.Client
                 if (disposing)
                 {
                     IsConnected = false;
-                    SonarQubeVersion = null;
+                    ServerInfo = null;
                     messageHandler.Dispose();
                 }
 

--- a/SonarQube.Client/SonarQubeService.cs
+++ b/SonarQube.Client/SonarQubeService.cs
@@ -36,10 +36,8 @@ namespace SonarQube.Client
 {
     public class SonarQubeService : ISonarQubeService, IDisposable
     {
-        internal static readonly Version OrganizationsFeatureMinimalVersion = new Version(6, 2);
-
         private readonly HttpMessageHandler messageHandler;
-        private readonly RequestFactory requestFactory;
+        private readonly IRequestFactory requestFactory;
         private readonly string userAgent;
         private readonly ILogger logger;
 
@@ -65,7 +63,7 @@ namespace SonarQube.Client
         {
         }
 
-        public SonarQubeService(HttpMessageHandler messageHandler, RequestFactory requestFactory, string userAgent, ILogger logger)
+        internal /* for testing */ SonarQubeService(HttpMessageHandler messageHandler, IRequestFactory requestFactory, string userAgent, ILogger logger)
         {
             if (messageHandler == null)
             {


### PR DESCRIPTION
Added IRequestHandler interface.
Combined the existing `SonarQubeVersion` and `IsSonarCloud` properties into a new `ServerInfo` class.
Updated the request handler to use `ServerInfo` rather than `Version`.

Relates to #80 / https://github.com/SonarSource/sonarlint-visualstudio/issues/2060