### PR TITLE
Update BouncyCastle to the latest version

### DIFF
--- a/SonarQube.Client.Tests/packages.lock.json
+++ b/SonarQube.Client.Tests/packages.lock.json
@@ -62,8 +62,8 @@
       },
       "BouncyCastle": {
         "type": "Transitive",
-        "resolved": "1.8.6.1",
-        "contentHash": "rkqpuKmJkdcfTMBkIj1b5nMdBAWKwAyh+I/BQYeqqSD2jkIlhwc9qBNKmSbnpmmm5c29qHZGLpvBSTNWvDLtQA=="
+        "resolved": "1.8.9",
+        "contentHash": "axnBgvdD5n+FnEG6efk/tfKuMFru7R/EoISH9zjh319yb3HD24TEHSAbNN/lTRT2ulOGRxDgOsCjkuk08iwWPg=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -106,7 +106,7 @@
       "sonarqube.client": {
         "type": "Project",
         "dependencies": {
-          "BouncyCastle": "1.8.6.1",
+          "BouncyCastle": "1.8.9",
           "Google.Protobuf": "3.6.1",
           "Grpc.Tools": "1.4.1",
           "Newtonsoft.Json": "13.0.1",

--- a/SonarQube.Client/SonarQube.Client.csproj
+++ b/SonarQube.Client/SonarQube.Client.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <!-- If we are building as part of SLVS use the shared AssemblyInfo file -->
-  <ItemGroup Condition=" Exists('$(SolutionDir)\src\AssemblyInfo.Shared.cs') " >
+  <ItemGroup Condition=" Exists('$(SolutionDir)\src\AssemblyInfo.Shared.cs') ">
     <Compile Remove="Properties\AssemblyInfo.cs" />
     <Compile Include="$(SolutionDir)\src\AssemblyInfo.Shared.cs" />
   </ItemGroup>
@@ -32,7 +32,7 @@
     <!-- When changing this reference update ProtocCompiler property too! -->
     <PackageReference Include="Grpc.Tools" Version="1.4.1" />
     <PackageReference Include="System.Net.Http" Version="4.0.0" />
-    <PackageReference Include="BouncyCastle" Version="1.8.6.1" />
+    <PackageReference Include="BouncyCastle" Version="1.8.9" />
   </ItemGroup>
 
   <!-- Exclude the protobuf-generated files from analysis -->

--- a/SonarQube.Client/packages.lock.json
+++ b/SonarQube.Client/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.6": {
       "BouncyCastle": {
         "type": "Direct",
-        "requested": "[1.8.6.1, )",
-        "resolved": "1.8.6.1",
-        "contentHash": "rkqpuKmJkdcfTMBkIj1b5nMdBAWKwAyh+I/BQYeqqSD2jkIlhwc9qBNKmSbnpmmm5c29qHZGLpvBSTNWvDLtQA=="
+        "requested": "[1.8.9, )",
+        "resolved": "1.8.9",
+        "contentHash": "axnBgvdD5n+FnEG6efk/tfKuMFru7R/EoISH9zjh319yb3HD24TEHSAbNN/lTRT2ulOGRxDgOsCjkuk08iwWPg=="
       },
       "Google.Protobuf": {
         "type": "Direct",


### PR DESCRIPTION
The old version (v1.8.6.1) had a vulnerability (CVE-2020-15522)
Our code as not impacted, but upgrading the component stops Mend/WhiteSource complaining.